### PR TITLE
Change routes name class to room

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   resources :coaches, only: [:index, :show]
 
   namespace :students do
-    resources :classes do
+    resources :rooms do
       resources :chat_messages, only: :index
     end
   end


### PR DESCRIPTION
# WHAT

ルーティングの名前の「class」を「room」
# WHY
- classでは予約語と被ってしまって使いにくい。
- lessonに対してclassというのは違いが分かりにくいので「room」という概念を用いる。「class」というよりもイメージしやすくなる。
