### PR TITLE
Fix coach_lesson_chat_index

### DIFF
--- a/app/views/coaches/students/show.html.haml
+++ b/app/views/coaches/students/show.html.haml
@@ -1,9 +1,25 @@
-%h2 生徒のやりとりをする教室
-%p
-  = @lesson.title
-  = image_tag @lesson.thumbnail
-  = @lesson.description
+- content_for :head do
+  = stylesheet_link_tag :show_application
+.show-wrapper
+  = image_tag @lesson.thumbnail, class: 'thumbnail-item'
+  .item-container
+    %span.genre-btn{ style: "border-color: ##{@lesson.genre.color}"}
+      = link_to @lesson.genre.name, lessons_genre_path(@lesson.genre_id), style: "color: ##{@lesson.genre.color}"
+    %p.main-title= @lesson.title
 
-= @student.email
-= link_to "チャット", coaches_lesson_student_chat_messages_path(@lesson, @student)
+    = link_to coaches_lesson_student_chat_messages_path(@lesson, @student) do
+      %p.chat-btn チャットを始める
 
+  .lesson-info
+    .sub-title
+      %p レッスン情報
+    %table.table-content
+      %tr
+        %td.table-title 申し込み期限
+        %td 2015/12/25
+      %tr
+        %td.table-title 現在の受講者
+        %td 1人
+      %tr
+        %td.table-title 今までの受講者
+        %td 10人


### PR DESCRIPTION
# what

コーチの担当レッスンの生徒詳細ページのエラーを解決
